### PR TITLE
unset-var-fix

### DIFF
--- a/demo/src/setup.py
+++ b/demo/src/setup.py
@@ -10,16 +10,17 @@ from setuptools import setup  # type: ignore
 with open(os.path.join(os.environ["RECIPE_DIR"], "meta.json"), "r", encoding="utf-8") as f:
     meta = json.load(f)
 
-pkgname = meta["name"]
+name_conda = meta["name"]
+name_py = name_conda.replace("-", "_")
 
 setup(
     entry_points={
         "console_scripts": [
-            "heythere = %s.core:main" % pkgname,
+            "heythere = %s.core:main" % name_py,
         ]
     },
-    name=pkgname,
-    package_data={pkgname: ["resources/conf.json"]},
-    packages=[pkgname],
+    name=name_conda,
+    package_data={name_py: ["resources/conf.json"]},
+    packages=[name_py],
     version=meta["version"],
 )

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: condev
-  version: 0.1.0
+  version: 0.1.1
 source:
   path: ../src
 build:

--- a/src/bash/condev-shell
+++ b/src/bash/condev-shell
@@ -2,11 +2,16 @@
 
 set -eu
 
-condev_activate() {
+condev_activate_devenv() {
   local name=$1
   condev_msg "Activating environment $name"
-  set +u && conda activate $name && set -u
+  condev_activate_safe $name
   condev_msg "Development environment active (type 'exit' when finished)"
+}
+
+condev_activate_safe() {
+  local name=${1:-base}
+  set +u && conda activate $name && set -u
 }
 
 condev_create() {
@@ -15,7 +20,7 @@ condev_create() {
   meta=$2
   condev_msg "Creating environment $name"
   conda create -y -n $name --file <( jq -r .packages[] $meta ) --repodata-fn repodata.json
-  condev_activate $name
+  condev_activate_devenv $name
   srcdir=$(jq -r .source $meta)
   if [[ -e $srcdir/setup.py ]]; then
     condev_msg "Doing editable install with setuptools"
@@ -49,13 +54,13 @@ condev_rc() {
   local func meta name
   test -e ~/.bashrc && source ~/.bashrc
   source $(realpath $(dirname $CONDA)/../etc/profile.d/conda.sh)
-  conda activate
+  condev_activate_safe
   condev_msg "Preparing development environment"
   condev_manage_recipe_dir
   make meta
   meta=$(realpath $PWD/recipe/meta.json)
   name=${DEV_ENV_PREFIX:-DEV}-$(jq -r .name $meta)
-  conda env list | grep -q "^$name " && condev_activate $name || condev_create $name $meta
+  conda env list | grep -q "^$name " && condev_activate_devenv $name || condev_create $name $meta
   for func in $(declare -F | grep condev_ | cut -d' ' -f3); do
     unset $func
   done
@@ -78,7 +83,7 @@ EOF
 }
 
 condev_shell() {
-  test -z "${CONDA_DEFAULT_ENV:-}" && eval "$(conda shell.bash hook)" && conda activate
+  test -z "${CONDA_DEFAULT_ENV:-}" && eval "$(conda shell.bash hook)" && condev_activate_safe
   local vars=( CONDA=$CONDA_EXE )
   env ${vars[@]} /bin/bash --rcfile <( sed -e "s/^condev_shell$/condev_rc/" $0 )
 }

--- a/src/setup.py
+++ b/src/setup.py
@@ -10,16 +10,17 @@ from setuptools import setup  # type: ignore
 with open(os.path.join(os.environ["RECIPE_DIR"], "meta.json"), "r", encoding="utf-8") as f:
     meta = json.load(f)
 
-pkgname = meta["name"]
+name_conda = meta["name"]
+name_py = name_conda.replace("-", "_")
 
 setup(
     entry_points={
         "console_scripts": [
-            "condev-meta = %s.meta:main" % pkgname,
+            "condev-meta = %s.meta:main" % name_py,
         ]
     },
-    name=pkgname,
-    packages=[pkgname],
+    name=name_conda,
+    packages=[name_py],
     scripts=["bash/condev-shell"],
     version=meta["version"],
 )


### PR DESCRIPTION
- Protect against unset variables in `condev-shell` script.
- Differentiate between conda and python package names (hyphen vs underscore).