### PR TITLE
srcdir-jq-fix

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: condev
-  version: 0.1.4
+  version: 0.1.5
 source:
   path: ../src
 build:

--- a/src/bash/condev-shell
+++ b/src/bash/condev-shell
@@ -18,10 +18,10 @@ condev_create() {
   local meta name srcdir
   name=$1
   meta=$2
+  srcdir=$(jq -r .source $meta)
   condev_msg "Creating environment $name"
   conda create -y -n $name --file <( jq -r .packages[] $meta ) --repodata-fn repodata.json
   condev_activate_devenv $name
-  srcdir=$(jq -r .source $meta)
   if [[ -e $srcdir/setup.py ]]; then
     condev_msg "Doing editable install with setuptools"
     if ! (cd $srcdir && pip install --editable .); then


### PR DESCRIPTION
Previous code tried to use `jq` from the development environment, where it may not be present.